### PR TITLE
修改判断`type`的方式

### DIFF
--- a/writer-opts.js
+++ b/writer-opts.js
@@ -61,53 +61,53 @@ function getWriterOpts() {
       })
 
       if (emojis) {
-        if (commit.type === `feat`) {
+        if ((commit.header).includes(`feat(`)) {
           commit.type = `✨ Features`
-        } else if (commit.type === `fix`) {
+        } else if ((commit.header).includes(`fix(`)) {
           commit.type = `🐛 Bug Fixes`
-        } else if (commit.type === `perf`) {
+        } else if ((commit.header).includes(`perf(`)) {
           commit.type = `⚡ Performance Improvements`
-        } else if (commit.type === `revert`) {
+        } else if ((commit.header).includes(`revert(`)) {
           commit.type = `⏪ Reverts`
-        } else if (commit.type === `docs`) {
+        } else if ((commit.header).includes(`docs(`)) {
           commit.type = `📝 Documentation`
-        } else if (commit.type === `style`) {
+        } else if ((commit.header).includes(`style(`)) {
           commit.type = `💄 Styles`
-        } else if (commit.type === `refactor`) {
+        } else if ((commit.header).includes(`refactor(`)) {
           commit.type = `♻ Code Refactoring`
-        } else if (commit.type === `test`) {
+        } else if ((commit.header).includes(`test(`)) {
           commit.type = `✅ Tests`
-        } else if (commit.type === `build`) {
+        } else if ((commit.header).includes(`build(`)) {
           commit.type = `👷‍ Build System`
-        } else if (commit.type === `ci`) {
+        } else if ((commit.header).includes(`ci(`)) {
           commit.type = `🔧 Continuous Integration`
-        } else if (commit.type === 'chore') {
+        } else if ((commit.header).includes('chore(')) {
           commit.type = '🎫 Chores'
         } else if (discard) {
           return
         }
       } else {
-        if (commit.type === `feat`) {
+        if ((commit.header).includes(`feat(`)) {
           commit.type = `Features`
-        } else if (commit.type === `fix`) {
+        } else if ((commit.header).includes(`fix(`)) {
           commit.type = `Bug Fixes`
-        } else if (commit.type === `perf`) {
+        } else if ((commit.header).includes(`perf(`)) {
           commit.type = `Performance Improvements`
-        } else if (commit.type === `revert`) {
+        } else if ((commit.header).includes(`revert(`)) {
           commit.type = `Reverts`
-        } else if (commit.type === `docs`) {
+        } else if ((commit.header).includes(`docs(`)) {
           commit.type = `Documentation`
-        } else if (commit.type === `style`) {
+        } else if ((commit.header).includes(`style(`)) {
           commit.type = `Styles`
-        } else if (commit.type === `refactor`) {
+        } else if ((commit.header).includes(`refactor(`)) {
           commit.type = `Code Refactoring`
-        } else if (commit.type === `test`) {
+        } else if ((commit.header).includes(`test(`)) {
           commit.type = `Tests`
-        } else if (commit.type === `build`) {
+        } else if ((commit.header).includes(`build(`)) {
           commit.type = `Build System`
-        } else if (commit.type === `ci`) {
+        } else if ((commit.header).includes(`ci(`)) {
           commit.type = `Continuous Integration`
-        } else if (commit.type === 'chore') {
+        } else if ((commit.header).includes('chore(')) {
           commit.type = 'Chores'
         } else if (discard) {
           return

--- a/writer-opts.js
+++ b/writer-opts.js
@@ -61,53 +61,53 @@ function getWriterOpts() {
       })
 
       if (emojis) {
-        if ((commit.header).includes(`feat(`)) {
+        if ((commit.header).includes(`feat(`) || commit.type === 'feat') {
           commit.type = `✨ Features`
-        } else if ((commit.header).includes(`fix(`)) {
+        } else if ((commit.header).includes(`fix(`) || commit.type === 'fix') {
           commit.type = `🐛 Bug Fixes`
-        } else if ((commit.header).includes(`perf(`)) {
+        } else if ((commit.header).includes(`perf(`) || commit.type === 'perf') {
           commit.type = `⚡ Performance Improvements`
-        } else if ((commit.header).includes(`revert(`)) {
+        } else if ((commit.header).includes(`revert(`) || commit.type === 'revert') {
           commit.type = `⏪ Reverts`
-        } else if ((commit.header).includes(`docs(`)) {
+        } else if ((commit.header).includes(`docs(`) || commit.type === 'docs') {
           commit.type = `📝 Documentation`
-        } else if ((commit.header).includes(`style(`)) {
+        } else if ((commit.header).includes(`style(`) || commit.type === 'style') {
           commit.type = `💄 Styles`
-        } else if ((commit.header).includes(`refactor(`)) {
+        } else if ((commit.header).includes(`refactor(`) || commit.type === 'refactor') {
           commit.type = `♻ Code Refactoring`
-        } else if ((commit.header).includes(`test(`)) {
+        } else if ((commit.header).includes(`test(`) || commit.type === 'test') {
           commit.type = `✅ Tests`
-        } else if ((commit.header).includes(`build(`)) {
+        } else if ((commit.header).includes(`build(`) || commit.type === 'build') {
           commit.type = `👷‍ Build System`
-        } else if ((commit.header).includes(`ci(`)) {
+        } else if ((commit.header).includes(`ci(`) || commit.type === 'ci') {
           commit.type = `🔧 Continuous Integration`
-        } else if ((commit.header).includes('chore(')) {
+        } else if ((commit.header).includes('chore(') || commit.type === 'chore') {
           commit.type = '🎫 Chores'
         } else if (discard) {
           return
         }
       } else {
-        if ((commit.header).includes(`feat(`)) {
+        if ((commit.header).includes(`feat(`) || commit.type === 'feat') {
           commit.type = `Features`
-        } else if ((commit.header).includes(`fix(`)) {
+        } else if ((commit.header).includes(`fix(`) || commit.type === 'fix') {
           commit.type = `Bug Fixes`
-        } else if ((commit.header).includes(`perf(`)) {
+        } else if ((commit.header).includes(`perf(`) || commit.type === 'perf') {
           commit.type = `Performance Improvements`
-        } else if ((commit.header).includes(`revert(`)) {
+        } else if ((commit.header).includes(`revert(`) || commit.type === 'revert') {
           commit.type = `Reverts`
-        } else if ((commit.header).includes(`docs(`)) {
+        } else if ((commit.header).includes(`docs(`) || commit.type === 'docs') {
           commit.type = `Documentation`
-        } else if ((commit.header).includes(`style(`)) {
+        } else if ((commit.header).includes(`style(`) || commit.type === 'style') {
           commit.type = `Styles`
-        } else if ((commit.header).includes(`refactor(`)) {
+        } else if ((commit.header).includes(`refactor(`) || commit.type === 'refactor') {
           commit.type = `Code Refactoring`
-        } else if ((commit.header).includes(`test(`)) {
+        } else if ((commit.header).includes(`test(`) || commit.type === 'test') {
           commit.type = `Tests`
-        } else if ((commit.header).includes(`build(`)) {
+        } else if ((commit.header).includes(`build(`) || commit.type === 'build') {
           commit.type = `Build System`
-        } else if ((commit.header).includes(`ci(`)) {
+        } else if ((commit.header).includes(`ci(`) || commit.type === 'ci') {
           commit.type = `Continuous Integration`
-        } else if ((commit.header).includes('chore(')) {
+        } else if ((commit.header).includes('chore(') || commit.type === 'chore') {
           commit.type = 'Chores'
         } else if (discard) {
           return


### PR DESCRIPTION
修改说明：
  将原本`write-opt`文件中，对type判断的方式进行修改，将
```javascript
if (commit.type === `feat`) {
    ...do some thing
}
```
修改成
```javascript
if ((commit.header).includes(`feat(`)) {
    ...do some thing
}
```
修改原因：
正常且规范的提交，肯定是`type(scope): body `，但是可能会有些其他的情况，最典型的就是`vscode`的一个比较火的插件`git-commit-plugin`，这个插件会生成一个带有`emoji`的`commit`，格式如下:`🌟 feat(scope):  body`，这时候就会无法生成日志文件，所以根据这种情况，做了如下的修改